### PR TITLE
Downgrade `python` interpreter requirement for Debian 11 Bullseye

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ license = "MIT"
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = "^3.10"
+python = "^3.9.2"
 simpy = "^4"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
I verified this by simply doing `poetry run demo` which seemed to exit successfully.