### PR TITLE
Add `.vscode/settings.json` to enable testing support in VS Code

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,14 @@
+{
+    "python.testing.unittestArgs": [
+        "-s",
+        "./simtfl",
+        "-t",
+        ".",
+        "-p",
+        "[a-z]*.py",
+        "--verbose",
+        "--buffer"
+    ],
+    "python.testing.pytestEnabled": false,
+    "python.testing.unittestEnabled": true
+}


### PR DESCRIPTION
To run tests in VS Code, click the flask icon and then the right arrow next to "simtfl".